### PR TITLE
Custom Logger class and getLogger

### DIFF
--- a/Core/automation/jsr223/python/core/components/100_DirectoryTrigger.py
+++ b/Core/automation/jsr223/python/core/components/100_DirectoryTrigger.py
@@ -18,9 +18,9 @@ except:
     from org.eclipse.smarthome.core.service import AbstractWatchService
 
 import core
-from core.log import logging, log_traceback, LOG_PREFIX
+from core.log import getLogger, log_traceback
 
-LOG = logging.getLogger("{}.core.DirectoryEventTrigger".format(LOG_PREFIX))
+LOG = getLogger("core.DirectoryEventTrigger")
 core.DIRECTORY_TRIGGER_MODULE_ID = "jsr223.DirectoryEventTrigger"
 
 scriptExtension.importPreset("RuleSimple")

--- a/Core/automation/jsr223/python/core/components/100_StartupTrigger.py
+++ b/Core/automation/jsr223/python/core/components/100_StartupTrigger.py
@@ -7,14 +7,14 @@ scriptExtension.importPreset("RuleSupport")
 scriptExtension.importPreset("RuleFactories")
 
 import core
-from core.log import logging, LOG_PREFIX
+from core.log import getLogger
 
 try:
     from org.openhab.core.automation.handler import TriggerHandler
 except:
     from org.eclipse.smarthome.automation.handler import TriggerHandler
 
-LOG = logging.getLogger("{}.core.StartupTrigger".format(LOG_PREFIX))
+LOG = getLogger("core.StartupTrigger")
 
 core.STARTUP_MODULE_ID = "jsr223.StartupTrigger"
 

--- a/Core/automation/lib/python/core/items.py
+++ b/Core/automation/lib/python/core/items.py
@@ -9,7 +9,7 @@ scriptExtension.importPreset(None)
 
 import core
 from core import osgi
-from core.log import logging, LOG_PREFIX
+from core.log import getLogger
 from core.links import remove_all_links
 
 ItemBuilderFactory = osgi.get_service(
@@ -24,7 +24,7 @@ ManagedItemProvider = osgi.get_service(
         "org.eclipse.smarthome.core.items.ManagedItemProvider"
     )
 
-log = logging.getLogger("{}.core.items".format(LOG_PREFIX))
+log = getLogger("core.items")
 
 def add_item(item_or_item_name, item_type=None, category=None, groups=None, label=None, tags=[], gi_base_type=None, group_function=None):
     """

--- a/Core/automation/lib/python/core/links.py
+++ b/Core/automation/lib/python/core/links.py
@@ -8,7 +8,7 @@ __all__ = [
 ]
 
 from core import osgi
-from core.log import logging, LOG_PREFIX
+from core.log import getLogger
 from core.utils import validate_item, validate_channel_uid
 
 try:
@@ -28,7 +28,7 @@ MANAGED_ITEM_CHANNEL_LINK_PROVIDER = osgi.get_service(
         "org.eclipse.smarthome.core.thing.link.ManagedItemChannelLinkProvider"
     )
 
-LOG = logging.getLogger(u"{}.core.links".format(LOG_PREFIX))
+LOG = getLogger(u"core.links")
 
 
 def add_link(item_or_item_name, channel_uid_or_string):

--- a/Core/automation/lib/python/core/metadata.py
+++ b/Core/automation/lib/python/core/metadata.py
@@ -50,7 +50,7 @@ __all__ = [
 ]
 
 from core import osgi
-from core.log import logging, LOG_PREFIX
+from core.log import getLogger
 
 try:
     from org.openhab.core.items import Metadata, MetadataKey
@@ -63,7 +63,7 @@ METADATA_REGISTRY = osgi.get_service(
         "org.eclipse.smarthome.core.items.MetadataRegistry"
     )
 
-LOG = logging.getLogger(u"{}.core.metadata".format(LOG_PREFIX))
+LOG = getLogger(u"core.metadata")
 
 
 def get_all_namespaces(item_name):
@@ -84,7 +84,7 @@ def get_all_namespaces(item_name):
         list: a list of strings representing the namespace names found for the
         specified Item
     """
-    LOG.debug(u"get_all_namespaces: Item '{}'".format(item_name))
+    LOG.trace(u"get_all_namespaces: Item '{}'".format(item_name))
     return [metadata.UID.namespace for metadata in METADATA_REGISTRY.getAll() if metadata.UID.itemName == item_name]
 
 
@@ -108,7 +108,7 @@ def get_metadata(item_name, namespace):
         ``value`` and ``configuration`` dictionary, but will be ``None`` if
         the namespace or the Item does not exist
     """
-    LOG.debug(u"get_metadata: Item '{}', namespace '{}'".format(item_name, namespace))
+    LOG.trace(u"get_metadata: Item '{}', namespace '{}'".format(item_name, namespace))
     return METADATA_REGISTRY.get(MetadataKey(namespace, item_name))
 
 
@@ -140,14 +140,14 @@ def set_metadata(item_name, namespace, configuration, value=None, overwrite=Fals
         remove_metadata(item_name, namespace)
     metadata = get_metadata(item_name, namespace)
     if metadata is None or overwrite:
-        LOG.debug(u"set_metadata: adding or overwriting metadata namespace with 'value: {}, configuration: {}': Item '{}', namespace '{}'".format(value, configuration, item_name, namespace))
+        LOG.trace(u"set_metadata: adding or overwriting metadata namespace with 'value: {}, configuration: {}': Item '{}', namespace '{}'".format(value, configuration, item_name, namespace))
         METADATA_REGISTRY.add(Metadata(MetadataKey(namespace, item_name), value, configuration))
     else:
         if value is None:
             value = metadata.value
         new_configuration = dict(metadata.configuration).copy()
         new_configuration.update(configuration)
-        LOG.debug(u"set_metadata: setting metadata namespace to 'value: {}, configuration: {}': Item '{}', namespace '{}'".format(value, new_configuration, item_name, namespace))
+        LOG.trace(u"set_metadata: setting metadata namespace to 'value: {}, configuration: {}': Item '{}', namespace '{}'".format(value, new_configuration, item_name, namespace))
         METADATA_REGISTRY.update(Metadata(MetadataKey(namespace, item_name), value, new_configuration))
 
 
@@ -171,10 +171,10 @@ def remove_metadata(item_name, namespace=None):
             remove metadata in all namespaces for the specified Item
     """
     if namespace is None:
-        LOG.debug(u"remove_metadata (all): Item '{}'".format(item_name))
+        LOG.trace(u"remove_metadata (all): Item '{}'".format(item_name))
         METADATA_REGISTRY.removeItemMetadata(item_name)
     else:
-        LOG.debug(u"remove_metadata: Item '{}', namespace '{}'".format(item_name, namespace))
+        LOG.trace(u"remove_metadata: Item '{}', namespace '{}'".format(item_name, namespace))
         METADATA_REGISTRY.remove(MetadataKey(namespace, item_name))
 
 
@@ -200,7 +200,7 @@ def get_key_value(item_name, namespace, *args):
         Item or namespace does not exist, this function will return an empty
         dictionary.
     """
-    LOG.debug(u"get_key_value: Item '{}', namespace '{}', args '{}'".format(item_name, namespace, args))
+    LOG.trace(u"get_key_value: Item '{}', namespace '{}', args '{}'".format(item_name, namespace, args))
     metadata = get_metadata(item_name, namespace)
     if metadata is not None:
         result = metadata.configuration.get(args[0])
@@ -231,7 +231,7 @@ def set_key_value(item_name, namespace, *args):
             branches can be used)
         value (str, decimal, boolean, dict or None): value to set
     """
-    LOG.debug(u"set_key_value: Item '{}', namespace '{}', args '{}'".format(item_name, namespace, args))
+    LOG.trace(u"set_key_value: Item '{}', namespace '{}', args '{}'".format(item_name, namespace, args))
     if len(args) > 1:
         metadata = get_metadata(item_name, namespace)
         new_configuration = {}
@@ -266,7 +266,7 @@ def remove_key_value(item_name, namespace, *args):
         key (str): ``configuration`` key to remove (multiple keys in
             descending branches can be used)
     """
-    LOG.debug(u"remove_key_value: Item '{}', namespace '{}', args '{}'".format(item_name, namespace, args))
+    LOG.trace(u"remove_key_value: Item '{}', namespace '{}', args '{}'".format(item_name, namespace, args))
     if args:
         metadata = get_metadata(item_name, namespace)
         if metadata is not None:
@@ -305,7 +305,7 @@ def get_value(item_name, namespace):
         str or None: namespace ``value`` or ``None`` if the namespace or
         Item does not exist
     """
-    LOG.debug(u"get_value: Item '{}', namespace '{}'".format(item_name, namespace))
+    LOG.trace(u"get_value: Item '{}', namespace '{}'".format(item_name, namespace))
     metadata = get_metadata(item_name, namespace)
     if metadata is not None:
         return metadata.value
@@ -329,7 +329,7 @@ def set_value(item_name, namespace, value):
         namespace (str): name of the namespace
         value (str): new or updated namespace value
     """
-    LOG.debug(u"set_value: Item '{}', namespace '{}', value '{}'".format(item_name, namespace, value))
+    LOG.trace(u"set_value: Item '{}', namespace '{}', value '{}'".format(item_name, namespace, value))
     metadata = get_metadata(item_name, namespace)
     if metadata is not None:
         set_metadata(item_name, namespace, metadata.configuration, value, True)

--- a/Core/automation/lib/python/core/osgi/__init__.py
+++ b/Core/automation/lib/python/core/osgi/__init__.py
@@ -12,12 +12,12 @@ __all__ = [
 
 from core.jsr223.scope import scriptExtension
 from org.osgi.framework import FrameworkUtil
-from core.log import logging, LOG_PREFIX
+from core.log import getLogger
 
 _BUNDLE = FrameworkUtil.getBundle(type(scriptExtension))
 BUNDLE_CONTEXT = _BUNDLE.getBundleContext() if _BUNDLE else None
 REGISTERED_SERVICES = {}
-LOG = logging.getLogger("{}.core.osgi".format(LOG_PREFIX))
+LOG = getLogger("core.osgi")
 
 
 def get_service(class_or_name):

--- a/Core/automation/lib/python/core/osgi/events.py
+++ b/Core/automation/lib/python/core/osgi/events.py
@@ -25,9 +25,9 @@ from core.jsr223.scope import scriptExtension
 scriptExtension.importPreset("RuleSupport")
 from core.jsr223.scope import Trigger, TriggerBuilder, Configuration
 from core.osgi import BUNDLE_CONTEXT
-from core.log import logging, LOG_PREFIX
+from core.log import getLogger
 
-LOG = logging.getLogger(u"{}.core.osgi.events".format(LOG_PREFIX))
+LOG = getLogger(u"core.osgi.events")
 
 
 def hashtable(*key_values):
@@ -50,13 +50,13 @@ class OsgiEventAdmin(object):
 
     _event_handler = None
     event_listeners = []
-    log = logging.getLogger(u"{}.core.osgi.events.OsgiEventAdmin".format(LOG_PREFIX))
+    log = getLogger(u"core.osgi.events.OsgiEventAdmin")
 
     # Singleton
     class OsgiEventHandler(EventHandler):
 
         def __init__(self):
-            self.log = logging.getLogger("{}.core.osgi.events.OsgiEventHandler")
+            self.log = getLogger("core.osgi.events.OsgiEventHandler")
             self.registration = BUNDLE_CONTEXT.registerService(
                 EventHandler, self, hashtable((EventConstants.EVENT_TOPIC, ["*"])))
             self.log.info("Registered openHAB OSGi event listener service")

--- a/Core/automation/lib/python/core/rules.py
+++ b/Core/automation/lib/python/core/rules.py
@@ -19,10 +19,10 @@ from inspect import isclass
 # except:
 #     from org.eclipse.smarthome.automation import Rule as SmarthomeRule
 
-from core.log import logging, LOG_PREFIX, log_traceback
+from core.log import getLogger, log_traceback
 from core.jsr223.scope import SimpleRule, scriptExtension
 
-LOG = logging.getLogger("{}.core.rules".format(LOG_PREFIX))
+LOG = getLogger("core.rules")
 
 scriptExtension.importPreset("RuleSimple")
 
@@ -58,7 +58,7 @@ def rule(name=None, description=None, tags=None):
                 else:
                     self.name = name
                 # set_uid_prefix(self)
-                self.log = logging.getLogger(u"{}.{}".format(LOG_PREFIX, self.name))
+                self.log = getLogger(self.name)
                 class_.__init__(self, *args, **kwargs)
                 if description is not None:
                     self.description = description
@@ -95,7 +95,7 @@ class _FunctionRule(SimpleRule):
             else:
                 name = "JSR223-Jython"
         self.name = name
-        callback.log = logging.getLogger(u"{}.{}".format(LOG_PREFIX, name))
+        callback.log = getLogger(name)
         callback.name = name
         self.callback = callback
         if description is not None:

--- a/Core/automation/lib/python/core/triggers.py
+++ b/Core/automation/lib/python/core/triggers.py
@@ -77,7 +77,7 @@ def when(target):
 
         itemRegistry = scriptExtension.get("itemRegistry")
         things = scriptExtension.get("things")
-        from core.log import logging, LOG_PREFIX
+        from core.log import getLogger
 
         try:
             from org.openhab.core.thing import ChannelUID, ThingUID, ThingStatus
@@ -91,7 +91,7 @@ def when(target):
         except:
             from org.openhab.core.types import TypeParser
 
-        LOG = logging.getLogger(u"{}.core.triggers".format(LOG_PREFIX))
+        LOG = getLogger(u"core.triggers")
 
 
         def item_trigger(function):
@@ -130,14 +130,14 @@ def when(target):
                         function.triggers.append(ItemCommandTrigger(member.name, command=new_state, trigger_name=trigger_name).trigger)
                     else:
                         function.triggers.append(ItemStateChangeTrigger(member.name, previous_state=old_state, state=new_state, trigger_name=trigger_name).trigger)
-                    LOG.debug(u"when: Created item_trigger: '{}'".format(trigger_name))
+                    LOG.trace(u"when: Created item_trigger: '{}'".format(trigger_name))
             return function
 
         def cron_trigger(function):
             if not hasattr(function, 'triggers'):
                 function.triggers = []
             function.triggers.append(CronTrigger(trigger_type, trigger_name=trigger_name).trigger)
-            LOG.debug(u"when: Created cron_trigger: '{}'".format(trigger_name))
+            LOG.trace(u"when: Created cron_trigger: '{}'".format(trigger_name))
             return function
 
         def system_trigger(function):
@@ -147,7 +147,7 @@ def when(target):
             function.triggers.append(StartupTrigger(trigger_name=trigger_name).trigger)
             #else:
             #    function.triggers.append(ShutdownTrigger(trigger_name=trigger_name).trigger)
-            LOG.debug(u"when: Created system_trigger: '{}'".format(trigger_name))
+            LOG.trace(u"when: Created system_trigger: '{}'".format(trigger_name))
             return function
 
         def thing_trigger(function):
@@ -168,14 +168,14 @@ def when(target):
             else:
                 event_types = "ThingStatusInfoChangedEvent" if trigger_type == "changed" else "ThingStatusInfoEvent"
                 function.triggers.append(ThingEventTrigger(event_types, trigger_target, trigger_name=trigger_name).trigger)
-            LOG.debug(u"when: Created thing_trigger: '{}'".format(trigger_name))
+            LOG.trace(u"when: Created thing_trigger: '{}'".format(trigger_name))
             return function
 
         def channel_trigger(function):
             if not hasattr(function, 'triggers'):
                 function.triggers = []
             function.triggers.append(ChannelEventTrigger(trigger_target, event=new_state, trigger_name=trigger_name).trigger)
-            LOG.debug(u"when: Created channel_trigger: '{}'".format(trigger_name))
+            LOG.trace(u"when: Created channel_trigger: '{}'".format(trigger_name))
             return function
 
         def directory_trigger(function):
@@ -191,7 +191,7 @@ def when(target):
             if event_kinds == []:
                 event_kinds = [ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY]
             function.triggers.append(DirectoryEventTrigger(trigger_target, event_kinds=event_kinds, watch_subdirectories=target_type == "Subdirectory", trigger_name=trigger_name).trigger)
-            LOG.debug(u"when: Created channel_trigger: '{}'".format(trigger_name))
+            LOG.trace(u"when: Created channel_trigger: '{}'".format(trigger_name))
             return function
 
         target_type = None
@@ -339,7 +339,7 @@ def when(target):
         elif target_type in ["Directory", "Subdirectory"] and any(event_kind for event_kind in trigger_type if event_kind not in ["created", "deleted", "modified"]):
             raise ValueError(u"when: \"{}\" could not be parsed. trigger_target '{}' is invalid for target_type '{}'.".format(target, trigger_target, target_type))
 
-        LOG.debug(u"when: target: '{}', target_type: '{}', trigger_target: '{}', trigger_type: '{}', old_state: '{}', new_state: '{}'".format(target, target_type, trigger_target, trigger_type, old_state, new_state))
+        LOG.trace(u"when: target: '{}', target_type: '{}', trigger_target: '{}', trigger_type: '{}', old_state: '{}', new_state: '{}'".format(target, target_type, trigger_target, trigger_type, old_state, new_state))
 
         trigger_name = validate_uid(trigger_name or target)
         if target_type in ["Item", "Member of", "Descendent of"]:

--- a/Core/automation/lib/python/core/utils.py
+++ b/Core/automation/lib/python/core/utils.py
@@ -32,11 +32,11 @@ except:
 
 from org.joda.time import DateTime
 
-from core.log import logging, LOG_PREFIX
+from core.log import getLogger
 from core.jsr223.scope import itemRegistry, NULL, UNDEF, ON, OFF, OPEN, CLOSED, events, things
 
 
-LOG = logging.getLogger(u"{}.core.utils".format(LOG_PREFIX))
+LOG = getLogger(u"core.utils")
 
 
 def validate_item(item_or_item_name):

--- a/Ivan's Changelog.md
+++ b/Ivan's Changelog.md
@@ -4,9 +4,12 @@ This change log will keep track of what has been done in the `ivans-updates` bra
 
 ## Added
 
+* Custom logger class and simplier `getLogger` function that automatically prepends the `LOG_PREFIX`.
+
 ## Changed
 
 * `when` and `addRule` now use `scriptExtension` instead of `scope`, see [commit](https://github.com/CrazyIvan359/openhab-helper-libraries/commit/cbc5e01b65cb614cced80e482b74dae523aed75f) for details.
+* Some core logging changed from `DEBUG` TO `TRACE`.
 
 ## Fixed
 


### PR DESCRIPTION
* Add custom logger class that supports `TRACE`
* Add simplier `getLogger` function that automatically prepends the `LOG_PREFIX`
* Move some core logging from `DEBUG` to `TRACE`

The new `getLogger` function (signature below) can be called simply with the name of the logger that you want and it will add the prefix automatically. Optionally you can pass a prefix as well.

```python
def getLogger(name, prefix=None):
```