### PR TITLE
Enable verbose testing

### DIFF
--- a/Core/automation/lib/python/core/testing.py
+++ b/Core/automation/lib/python/core/testing.py
@@ -46,7 +46,7 @@ def _run_test(test_case, out = None, verbosity=None):
     if out is not None:
         runner = unittest.TextTestRunner(out, verbosity=verbosity)
     else:
-        runner = unittest.TextTestRunner()
+        runner = unittest.TextTestRunner(resultclass=unittest.TestResult)
     result = runner.run(suite)
     json_result = _RESULT_TEMPLATE.format(
         run=result.testsRun, errors=_format_errors(result.errors),

--- a/Core/automation/lib/python/core/testing.py
+++ b/Core/automation/lib/python/core/testing.py
@@ -55,6 +55,21 @@ def _run_test(test_case, out = None, verbosity=None):
 
 
 def run_test(test_case, logger=logging.root, verbosity=None):
+    """
+    Runs a provided unittest.TestCase and sends the output to the log
+
+    Args:
+        test_case (unittest.TestCase): The test case (class) which will be run
+        logger: (optional) predefined core.log.logger instance. If not provided a basic default
+            logger will be used.
+        verbosity (int): (optional) Verbosity parameter to pass to the test case runner. If
+            provided, runner output will be directed to a temporary file and then fed to the
+            log line by line. If not provided, basic formatted results will be output to the log
+            without use of any temporary file.
+    Returns:
+        bool: ``True``, if no failures or errors were found, else ``False``
+        str: a unicode string containing json formatted test results.
+    """
     logger.info(u"Running tests: '{}'".format(test_case.__name__))
     if isinstance(verbosity, int):
         output = TemporaryFile()
@@ -67,11 +82,11 @@ def run_test(test_case, logger=logging.root, verbosity=None):
                 logger.error(line)
         output.close()
     else:
-        status, result = _run_test(test_case, verbosity)
-    if status:
-        logger.info(result)
-    else:
-        logger.error(result)
+        status, result = _run_test(test_case)
+        if status:
+            logger.info(result)
+        else:
+            logger.error(result)
     return (status, result)
 
 

--- a/Core/automation/lib/python/core/testing.py
+++ b/Core/automation/lib/python/core/testing.py
@@ -68,10 +68,10 @@ def run_test(test_case, logger=logging.root, verbosity=None):
         output.close()
     else:
         status, result = _run_test(test_case, verbosity)
-        if status:
-            logger.info(result)
-        else:
-            logger.error(result)
+    if status:
+        logger.info(result)
+    else:
+        logger.error(result)
     return (status, result)
 
 

--- a/Core/automation/lib/python/core/testing.py
+++ b/Core/automation/lib/python/core/testing.py
@@ -56,7 +56,7 @@ def _run_test(test_case, out = None, verbosity=None):
 
 def run_test(test_case, logger=logging.root, verbosity=None):
     logger.info(u"Running tests: '{}'".format(test_case.__name__))
-    if verbosity is not None:
+    if isinstance(verbosity, int):
         output = TemporaryFile()
         status, result = _run_test(test_case, output, verbosity)
         output.seek(0)


### PR DESCRIPTION
Change to `core.testing` to allow a choice to get more detailed testing results, using a temporary file to store test results.

Calling `core.testing.run_test()` with 'verbosity=<num>` as a parameter will now open a temporary file, redirect the TextTestRunner output to it, and then feed the test results to the log. If no verbosity is supplied, the result is unchanged.

Sample testing results before:

```
2021-02-22 12:10:35.410 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - Running tests: 'CoreUtilsTestCase'
2021-02-22 12:10:39.020 [WARN ] [jsr223.jython.core.utils            ] - 'DogeDoesNotExist' is not in the ItemRegistry
2021-02-22 12:10:43.604 [WARN ] [jsr223.jython.core.utils            ] - 'DogeDoesNotExist' is not in the ItemRegistry
2021-02-22 12:10:43.609 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - {
  "run": 17,
  "errors": ,
  "failures": ,
  "skipped": []
}
```

Sample test results after:

```
2021-02-22 12:56:04.743 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - Running tests: 'CoreUtilsTestCase'
2021-02-22 12:56:08.352 [WARN ] [jsr223.jython.core.utils            ] - 'DogeDoesNotExist' is not in the ItemRegistry
2021-02-22 12:56:13.345 [WARN ] [jsr223.jython.core.utils            ] - 'DogeDoesNotExist' is not in the ItemRegistry
2021-02-22 12:56:13.352 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_ColorType_for_color_item (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.354 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_DateTimeType_for_date_item (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.355 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_DecimalType_for_number_item (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.357 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_PercentType_for_dimmer_item (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.358 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_StringType_for_string_item (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.359 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_ZonedDateTime_for_date_item_with_return_type (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.360 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_datetime_for_date_item_with_return_type (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.361 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_default_for_non_existing_item_with_default (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.362 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_expected_color_for_color_item (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.364 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_expected_datetime_for_datetime_item (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.365 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_expected_int_for_number_item_with_return_type (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.366 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_expected_number_for_number_item (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.367 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_expected_percentage_for_dimmer_item (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.368 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_expected_string_for_number_item_with_return_type (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.369 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_expected_string_for_string_item (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.371 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_farenheit_for_number_item_with_unit (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.372 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - test_get_item_state_returns_none_for_non_existing_item_with_no_default (__main__.CoreUtilsTestCase) ... ok
2021-02-22 12:56:13.373 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - 
2021-02-22 12:56:13.374 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - ----------------------------------------------------------------------
2021-02-22 12:56:13.375 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - Ran 17 tests in 8.595s
2021-02-22 12:56:13.376 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - 
2021-02-22 12:56:13.377 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - OK
2021-02-22 12:56:13.379 [INFO ] [jsr223.jython.OHL-test-core.utils   ] - {
  "run": 17,
  "errors": ,
  "failures": ,
  "skipped": []
}
```

