### PR TITLE
disable check for trigger channel type

### DIFF
--- a/Core/automation/lib/python/core/triggers.py
+++ b/Core/automation/lib/python/core/triggers.py
@@ -366,8 +366,8 @@ def when(target):
             raise ValueError(u"when: \"{}\" could not be parsed. trigger_target '{}' is invalid for target_type 'Thing'. The only valid trigger_type values are 'added', 'removed', and 'updated'.".format(target, trigger_target))
         elif target_type == "Channel" and things.getChannel(ChannelUID(trigger_target)) is None:# returns null if Channel does not exist
             raise ValueError(u"when: \"{}\" could not be parsed because Channel '{}' does not exist".format(target, trigger_target))
-        elif target_type == "Channel" and things.getChannel(ChannelUID(trigger_target)).kind != ChannelKind.TRIGGER:
-            raise ValueError(u"when: \"{}\" could not be parsed because '{}' is not a trigger Channel".format(target, trigger_target))
+        #elif target_type == "Channel" and things.getChannel(ChannelUID(trigger_target)).kind != ChannelKind.TRIGGER:
+            #raise ValueError(u"when: \"{}\" could not be parsed because '{}' is not a trigger Channel".format(target, trigger_target))
         elif target_type == "System" and trigger_target != "started":# and trigger_target != "shuts down":
             raise ValueError(u"when: \"{}\" could not be parsed. trigger_target '{}' is invalid for target_type 'System'. The only valid trigger_type value is 'started'.".format(target, target_type))# and 'shuts down'".format(target, target_type))
         elif target_type in ["Directory", "Subdirectory"] and not path.isdir(trigger_target):


### PR DESCRIPTION
Since I've been using Jython scripting with OH 2.x and 3.x for some time now and always had to make this change in order to use Jython rules together with MQTT trigger channels (which are, for some reason, not of type TRIGGER_CHANNEL) I thought I'd leave this here as a pull request, maybe just to open up a discussion whether this check is necessary in the helper libraries or if the MQTT binding is broken when it comes to trigger channels (but as this has been for a long time I presume someone would have fixed this in the MQTT binding if it were a bug).

I need rules on MQTT trigger channels since I like to trigger certain actions when buttons connected to my Tasmota devices are pressed once or twice or being held for a second or so.

Example of a rule that doesn't work when the mentioned check is active:

```
@rule("Sleep: Turn off all lights")
@when("Channel mqtt:topic:Sleep_Light_Left:Button triggered HOLD")
@when("Channel mqtt:topic:Sleep_Light_Right:Button triggered HOLD")
def turnOffAllLights(event):
    events.sendCommand("g_Sleep_Light_All_On", "OFF")
```